### PR TITLE
v0.2.1: drop [tool.uv.sources] from the published manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ pip install rle-python-gee
 With [uv](https://docs.astral.sh/uv/) from a clone of this repo:
 
 ```bash
-uv sync          # installs rle-python-gee + rle-python (editable sibling)
+uv sync                                   # installs rle-python-gee + rle-python from git/PyPI
+```
+
+To develop against a sibling editable checkout of `rle-python` instead, add
+the override after sync:
+
+```bash
+uv sync
+uv pip install -e ../rle-python --reinstall   # swap in editable sibling
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rle-python-gee"
-version = "0.2.0"
+version = "0.2.1"
 description = "Google Earth Engine data-access backends for rle-python (IUCN Red List of Ecosystems)"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ rle-gee = "rle.gee.cli:app"
 [project.entry-points."rle.backends"]
 gee = "rle.gee._entrypoints:register"
 
-[tool.uv.sources]
-rle-python = { path = "../rle-python", editable = true }
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Problem

Downstream `pixi install` (e.g. in TEMPLATE-rle-assessment) fails with:

```
× failed to solve the pypi requirements
├─▶ Failed to download and build `rle-python @
    git+https://github.com/RLE-Assessment/rle-python-gee@v0.2.0#subdirectory=../rle-python`
╰─▶ The source distribution `…rle-python-gee@v0.2.0#subdirectory=../rle-python`
    has no subdirectory `../rle-python`
```

## Cause

v0.2.0's `pyproject.toml` carries

```toml
[tool.uv.sources]
rle-python = { path = "../rle-python", editable = true }
```

intended as a sibling-editable convenience for local development of this repo. uv, however, reads `tool.uv.sources` from a package's manifest even when that package is a transitive dependency, so it rewrites the downstream `rle-python` requirement into a synthetic `git+…/rle-python-gee@v0.2.0#subdirectory=../rle-python` URL — which has no such subdirectory and fails.

## Fix

- Remove the `[tool.uv.sources]` block.
- Document the manual sibling-editable workflow in the README (`uv sync && uv pip install -e ../rle-python --reinstall`).
- Bump to v0.2.1.

Downstream pins will be re-pointed to `tag = "v0.2.1"` in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)