### PR TITLE
Bump actions/checkout to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Why

GitHub is deprecating the **Node 20** action runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)): runners default node20 actions to Node 24 on **2026-06-16**, full removal fall 2026. This surfaced a deprecation warning in workflow logs.

## Changes

| Action | Old → New | Files |
|---|---|---|
| `actions/checkout` | v4 → **v5** | all 3 claude workflows |

`checkout@v4` runs on node20; `v5` runs on node24. `anthropics/claude-code-action@v1` (composite) is unchanged — it does not emit the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)